### PR TITLE
Fix 10 linter issues (gofmt, revive, staticcheck, unused)

### DIFF
--- a/perf_profiler.go
+++ b/perf_profiler.go
@@ -13,6 +13,7 @@ import (
 // ProfilerSection identifies which part of the frame is being profiled
 type ProfilerSection int
 
+// Profiler sections for frame timing breakdown.
 const (
 	ProfilerSectionUpdate ProfilerSection = iota
 	ProfilerSectionDraw
@@ -83,11 +84,11 @@ type PerformanceProfiler struct {
 	totalDrawCalls     int64
 
 	// Memory tracking
-	lastMemStats     runtime.MemStats
-	allocsThisFrame  uint64
-	bytesThisFrame   uint64
-	totalAllocs      uint64
-	totalAllocBytes  uint64
+	lastMemStats    runtime.MemStats
+	allocsThisFrame uint64
+	bytesThisFrame  uint64
+	totalAllocs     uint64
+	totalAllocBytes uint64
 
 	// GPU sync tracking
 	gpuSyncCount     int64
@@ -249,14 +250,14 @@ func (pp *PerformanceProfiler) RecordCacheMiss() {
 // PerformanceReport holds a snapshot of profiler statistics
 type PerformanceReport struct {
 	// Frame timing
-	AvgFrameTime    time.Duration `json:"avg_frame_time"`
-	MaxFrameTime    time.Duration `json:"max_frame_time"`
-	MinFrameTime    time.Duration `json:"min_frame_time"`
-	CurrentFPS      float64       `json:"current_fps"`
-	AvgFPS          float64       `json:"avg_fps"`
-	TargetFPS       int           `json:"target_fps"`
-	FrameBudget     time.Duration `json:"frame_budget"`
-	BudgetUsedPct   float64       `json:"budget_used_pct"`
+	AvgFrameTime  time.Duration `json:"avg_frame_time"`
+	MaxFrameTime  time.Duration `json:"max_frame_time"`
+	MinFrameTime  time.Duration `json:"min_frame_time"`
+	CurrentFPS    float64       `json:"current_fps"`
+	AvgFPS        float64       `json:"avg_fps"`
+	TargetFPS     int           `json:"target_fps"`
+	FrameBudget   time.Duration `json:"frame_budget"`
+	BudgetUsedPct float64       `json:"budget_used_pct"`
 
 	// Section breakdown (percentage of frame)
 	SectionBreakdown map[string]float64 `json:"section_breakdown"`
@@ -266,11 +267,11 @@ type PerformanceReport struct {
 	TotalDrawCalls    int64   `json:"total_draw_calls"`
 
 	// Memory
-	AllocsPerFrame  float64 `json:"allocs_per_frame"`
-	BytesPerFrame   float64 `json:"bytes_per_frame"`
-	HeapAllocMB     float64 `json:"heap_alloc_mb"`
-	HeapInUseMB     float64 `json:"heap_in_use_mb"`
-	NumGC           uint32  `json:"num_gc"`
+	AllocsPerFrame float64 `json:"allocs_per_frame"`
+	BytesPerFrame  float64 `json:"bytes_per_frame"`
+	HeapAllocMB    float64 `json:"heap_alloc_mb"`
+	HeapInUseMB    float64 `json:"heap_in_use_mb"`
+	NumGC          uint32  `json:"num_gc"`
 
 	// Cache efficiency
 	CacheHitRate float64 `json:"cache_hit_rate"`
@@ -480,4 +481,3 @@ func GetProfilingReport() PerformanceReport {
 func PrintProfilingReport() {
 	fmt.Println(GetPerformanceProfiler().FormatReport())
 }
-

--- a/pixel_batch.go
+++ b/pixel_batch.go
@@ -184,17 +184,17 @@ type BufferTier struct {
 
 // MultiTierBufferPool provides efficient buffer allocation for varying sizes
 type MultiTierBufferPool struct {
-	tiers    []*BufferTier
-	stats    BufferPoolStats
-	statsMu  sync.RWMutex
+	tiers   []*BufferTier
+	stats   BufferPoolStats
+	statsMu sync.RWMutex
 }
 
 // BufferPoolStats tracks pool performance
 type BufferPoolStats struct {
-	Hits       int64
-	Misses     int64
+	Hits        int64
+	Misses      int64
 	Allocations int64
-	Returns    int64
+	Returns     int64
 }
 
 // Pre-defined tier sizes (in pixels, multiply by 4 for bytes)
@@ -318,11 +318,11 @@ func (p *MultiTierBufferPool) Stats() BufferPoolStats {
 
 // SpriteBatchEntry represents a single sprite to be drawn
 type SpriteBatchEntry struct {
-	SrcImage *ebiten.Image
-	DstX, DstY float64
+	SrcImage       *ebiten.Image
+	DstX, DstY     float64
 	ScaleX, ScaleY float64
-	FlipX, FlipY bool
-	UseShader bool
+	FlipX, FlipY   bool
+	UseShader      bool
 }
 
 // SpriteBatchSystem batches sprite draw calls
@@ -452,4 +452,3 @@ func GetRect(x0, y0, x1, y1 int) *image.Rectangle {
 func PutRect(r *image.Rectangle) {
 	rectPool.Put(r)
 }
-

--- a/resource_lifecycle.go
+++ b/resource_lifecycle.go
@@ -15,6 +15,7 @@ import (
 // ResourceType identifies the type of tracked resource
 type ResourceType int
 
+// Resource types for lifecycle tracking.
 const (
 	ResourceTypeImage ResourceType = iota
 	ResourceTypeShader
@@ -58,7 +59,7 @@ type ResourceManager struct {
 	// Memory tracking
 	totalAllocated int64
 	peakAllocated  int64
-	
+
 	// Thresholds
 	memoryWarningThreshold int64 // Bytes - warn when exceeded
 	memoryLimitThreshold   int64 // Bytes - force cleanup when exceeded
@@ -320,7 +321,7 @@ func (di *DisposableImage) Dispose() {
 	}
 
 	di.disposed = true
-	di.Image.Deallocate()
+	di.Deallocate()
 	GetResourceManager().Release(di.resourceID)
 }
 
@@ -376,4 +377,3 @@ func StopMemoryWatcher() {
 		close(memoryWatcherStop)
 	}
 }
-

--- a/screen.go
+++ b/screen.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"image"
 	"image/color"
 	_ "image/png" // Keep in case other PNGs are loaded
 	"log"
@@ -940,37 +939,6 @@ func initShadowBuffer(width, height int) {
 	}
 }
 
-// pixelOverlay is a temporary image for compositing Pset pixels
-var pixelOverlay *ebiten.Image
-
-// flushPixelBuffer uploads all pending pixel changes to the GPU
-// Uses alpha blending so Pset pixels overlay shapes without erasing them
-func flushPixelBuffer() {
-	pixelBufferMutex.Lock()
-	defer pixelBufferMutex.Unlock()
-
-	if bufferDirty && currentScreen != nil && len(pixelBuffer) > 0 {
-		// Create or reuse overlay image
-		if pixelOverlay == nil || pixelOverlay.Bounds().Dx() != pixelBufferWidth || pixelOverlay.Bounds().Dy() != pixelBufferHeight {
-			pixelOverlay = ebiten.NewImage(pixelBufferWidth, pixelBufferHeight)
-		}
-
-		// Write pixels to overlay (includes transparent pixels where nothing was set)
-		pixelOverlay.WritePixels(pixelBuffer)
-
-		// Draw overlay onto screen with alpha blending
-		// Transparent pixels (alpha=0) won't overwrite the destination
-		opts := &ebiten.DrawImageOptions{}
-		opts.Blend = ebiten.BlendSourceOver
-		currentScreen.DrawImage(pixelOverlay, opts)
-
-		bufferDirty = false
-
-		// Update screen pixel cache after flushing
-		updateScreenPixelCache()
-	}
-}
-
 // setPixelInBuffer sets a pixel in the buffer without immediate GPU upload
 func setPixelInBuffer(x, y int, clr color.Color) {
 	if x < 0 || x >= pixelBufferWidth || y < 0 || y >= pixelBufferHeight {
@@ -998,25 +966,6 @@ func setPixelInBuffer(x, y int, clr color.Color) {
 		shadowBuffer[offset+2] = bByte
 		shadowBuffer[offset+3] = aByte
 	}
-}
-
-// clearPixelBuffer clears the pixel buffer and marks it as clean
-func clearPixelBuffer() {
-	pixelBufferMutex.Lock()
-	defer pixelBufferMutex.Unlock()
-
-	if len(pixelBuffer) > 0 {
-		for i := range pixelBuffer {
-			pixelBuffer[i] = 0
-		}
-		bufferDirty = false
-	}
-
-	// Also clear shadow buffer
-	clearShadowBuffer()
-
-	// Also invalidate screen pixel cache
-	invalidateScreenPixelCache()
 }
 
 // clearShadowBuffer clears the CPU shadow buffer
@@ -1060,50 +1009,6 @@ func MarkShadowBufferDirty() {
 // Kept for backward compatibility.
 func MarkShadowBufferDirtyFromSprite() {
 	MarkShadowBufferDirty()
-}
-
-// drawPixelImmediate draws a single pixel directly to the screen.
-// This preserves draw order by not using buffering.
-func drawPixelImmediate(x, y int, clr color.Color) {
-	if currentScreen == nil {
-		return
-	}
-
-	// Check bounds against the current screen
-	bounds := currentScreen.Bounds()
-	if x < bounds.Min.X || x >= bounds.Max.X || y < bounds.Min.Y || y >= bounds.Max.Y {
-		return // Silently ignore out-of-bounds pixels
-	}
-
-	// Initialize shadow buffer if needed
-	if shadowBuffer == nil {
-		initShadowBuffer(GetScreenWidth(), GetScreenHeight())
-	}
-
-	// Create a 1x1 pixel buffer
-	r, g, b, a := clr.RGBA()
-	rByte := uint8(r >> 8)
-	gByte := uint8(g >> 8)
-	bByte := uint8(b >> 8)
-	aByte := uint8(a >> 8)
-
-	singlePixel := []byte{rByte, gByte, bByte, aByte}
-
-	// Get a 1x1 sub-image at the target position and write the pixel
-	subImg := currentScreen.SubImage(image.Rect(x, y, x+1, y+1)).(*ebiten.Image)
-	subImg.WritePixels(singlePixel)
-
-	// Also update shadow buffer (for Pget without GPU sync)
-	if shadowBuffer != nil && shadowBufferValid &&
-		x >= 0 && x < shadowBufferWidth && y >= 0 && y < shadowBufferHeight {
-		offset := (y*shadowBufferWidth + x) * 4
-		if offset+3 < len(shadowBuffer) {
-			shadowBuffer[offset] = rByte
-			shadowBuffer[offset+1] = gByte
-			shadowBuffer[offset+2] = bByte
-			shadowBuffer[offset+3] = aByte
-		}
-	}
 }
 
 // syncShadowBufferFromGPU syncs the shadow buffer from the GPU.


### PR DESCRIPTION
## Summary
- Fix gofmt struct field alignment in `perf_profiler.go`, `pixel_batch.go`, and `resource_lifecycle.go`
- Add comments to exported const blocks `ProfilerSection` and `ResourceType` to satisfy revive
- Simplify embedded field selector `di.Image.Deallocate()` to `di.Deallocate()` (staticcheck QF1008)
- Remove 4 unused declarations from `screen.go`: `pixelOverlay`, `flushPixelBuffer`, `clearPixelBuffer`, `drawPixelImmediate`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` reports 0 issues


Made with [Cursor](https://cursor.com)